### PR TITLE
Add Namespace to message, add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+examples
+images

--- a/examples/slack8s-deployment.yaml
+++ b/examples/slack8s-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: slack8s
-          image: ultimateboy/slack8s
+          image: rosskukulinski/slack8s
           imagePullPolicy: Always
           env:
             - name: SLACK_TOKEN

--- a/main.go
+++ b/main.go
@@ -57,6 +57,11 @@ func send_message(e Event, color string) error {
 		Fallback: e.Message,
 		Fields: []slack.AttachmentField{
 			slack.AttachmentField{
+				Title: "Namespace",
+				Value: e.Metadata.Namespace,
+				Short: true,
+			},
+			slack.AttachmentField{
 				Title: "Message",
 				Value: e.Message,
 			},


### PR DESCRIPTION
This PR adds the Namespace to which the event belongs into the Slack message.  I also added a .dockerignore file so that the `examples` and `images` directories are not included in the docker image.
