### PR TITLE
Use kubernetes token from secrets instead of kubectl proxy

### DIFF
--- a/examples/slack8s-deployment.yaml
+++ b/examples/slack8s-deployment.yaml
@@ -33,8 +33,4 @@ spec:
                 configMapKeyRef:
                   name: slack8s
                   key: slack-channel
-        - name: kube-proxy
-          image: gcr.io/google_containers/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty
-          imagePullPolicy: Always
-          args: ["proxy", "-p", "8001"]
 


### PR DESCRIPTION
The Authorization token is stored in `/var/run/secrets/kubernetes.io/serviceaccount/token`. With this the master api can be accessed. The url of the master api is present in the environment variables `KUBERNETES_SERVICE_HOST` and `KUBERNETES_PORT_443_TCP_PORT`.

This will probably break local development though.
